### PR TITLE
Document filtering

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "compile": "rm -rf ./dist && tsc",
     "start": "node dist/server",
-    "dev": "docker-compose --env-file .env up -d postgres && nodemon",
+    "dev": "docker-compose --env-file .env up -d postgres && yarn migration:up && nodemon",
     "dev:container": "docker-compose --env-file .env up -d && docker-compose logs -f screening-server",
     "test": "jest --env=node --colors",
     "lint": "eslint . --ext .ts",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@controllers": "dist/app/controllers",
     "@services": "dist/app/services",
     "@mappers": "dist/app/mappers",
+    "@middlewares": "dist/app/middlewares",
     "@domain": "dist/domain/",
     "@repos": "dist/domain/repos",
     "@server": "dist/server",

--- a/src/app/controllers/document.controllers.ts
+++ b/src/app/controllers/document.controllers.ts
@@ -25,7 +25,8 @@ export class DocumentController {
         const documents = await this.documentService.getAll(filters, page, pageSize);
 
         res.status(200).send(documents);
-    });
+      },
+    );
 
     this.router.get('/:id', isAuthenticated, async (req: Request, res: Response) => {
       try {

--- a/src/app/controllers/document.controllers.ts
+++ b/src/app/controllers/document.controllers.ts
@@ -15,16 +15,21 @@ export class DocumentController {
       isAuthenticated,
       parseDocumentsFilters,
       async (req: Request, res: Response) => {
-        const page: number = typeof req.query.page === 'string' ? parseInt(req.query.page) : 0;
+        try {
+          const page: number = typeof req.query.page === 'string' ? parseInt(req.query.page) : 0;
 
-        const pageSize: number =
-          typeof req.query.pageSize === 'string' ? parseInt(req.query.pageSize) : 10;
+          const pageSize: number =
+            typeof req.query.pageSize === 'string' ? parseInt(req.query.pageSize) : 10;
 
-        const filters = req.documentsFilters ?? {};
+          const filters = req.documentsFilters ?? {};
 
-        const documents = await this.documentService.getAll(filters, page, pageSize);
+          const documents = await this.documentService.getAll(filters, page, pageSize);
 
-        res.status(200).send(documents);
+          res.status(200).send(documents);
+        } catch (error: any) {
+          const errorType: Exception = error.constructor.name;
+          return res.status(statusMap[errorType] ?? HttpStatus.INTERNAL_SERVER_ERROR).json(error);
+        }
       },
     );
 

--- a/src/app/controllers/document.controllers.ts
+++ b/src/app/controllers/document.controllers.ts
@@ -9,15 +9,38 @@ export class DocumentController {
   public router: Router = Router();
   constructor(@inject(TYPES.DOCUMENT_SERVICE) private readonly documentService: DocumentService) {
     this.router.get('/', async (req: Request, res: Response) => {
+      const token: string = req.headers['authorization'] ?? '';
+
+      if (token.length === 0) {
+        return res.status(HttpStatus.UNAUTHORIZED).json({});
+      }
+
       const page: number = typeof req.query.page === 'string' ? parseInt(req.query.page) : 0;
+
       const pageSize: number =
         typeof req.query.pageSize === 'string' ? parseInt(req.query.pageSize) : 10;
 
-      const documents = await this.documentService.getAll(page, pageSize);
+      let sourcesOfInterest: string[];
+
+      if (Array.isArray(req.query.sourcesOfInterest)) {
+        sourcesOfInterest = <string[]>req.query.sourcesOfInterest;
+      } else if (typeof req.query.sourcesOfInterest === 'string') {
+        sourcesOfInterest = [req.query.sourcesOfInterest];
+      } else {
+        sourcesOfInterest = req.query.sourcesOfInterest = [];
+      }
+
+      const documents = await this.documentService.getAll(sourcesOfInterest, page, pageSize);
       res.status(200).send(documents);
     });
 
     this.router.get('/:id', async (req: Request, res: Response) => {
+      const token: string = req.headers['authorization'] ?? '';
+
+      if (token.length === 0) {
+        return res.status(HttpStatus.UNAUTHORIZED).json({});
+      }
+
       try {
         const user = await this.documentService.getById(req.params.id);
         return res.status(HttpStatus.OK).json(user);

--- a/src/app/controllers/document.controllers.ts
+++ b/src/app/controllers/document.controllers.ts
@@ -1,6 +1,7 @@
 import { Exception, HttpStatus, statusMap } from '@lib';
 import { TYPES } from '@server/types';
 import { DocumentService } from '@services';
+import { isAuthenticated } from '@middlewares/isAuthenticated.middleware';
 import { Request, Response, Router } from 'express';
 import { inject, injectable } from 'inversify';
 
@@ -8,13 +9,7 @@ import { inject, injectable } from 'inversify';
 export class DocumentController {
   public router: Router = Router();
   constructor(@inject(TYPES.DOCUMENT_SERVICE) private readonly documentService: DocumentService) {
-    this.router.get('/', async (req: Request, res: Response) => {
-      const token: string = req.headers['authorization'] ?? '';
-
-      if (token.length === 0) {
-        return res.status(HttpStatus.UNAUTHORIZED).json({});
-      }
-
+    this.router.get('/', isAuthenticated, async (req: Request, res: Response) => {
       const page: number = typeof req.query.page === 'string' ? parseInt(req.query.page) : 0;
 
       const pageSize: number =
@@ -34,13 +29,7 @@ export class DocumentController {
       res.status(200).send(documents);
     });
 
-    this.router.get('/:id', async (req: Request, res: Response) => {
-      const token: string = req.headers['authorization'] ?? '';
-
-      if (token.length === 0) {
-        return res.status(HttpStatus.UNAUTHORIZED).json({});
-      }
-
+    this.router.get('/:id', isAuthenticated, async (req: Request, res: Response) => {
       try {
         const user = await this.documentService.getById(req.params.id);
         return res.status(HttpStatus.OK).json(user);

--- a/src/app/controllers/dtos/User.ts
+++ b/src/app/controllers/dtos/User.ts
@@ -4,6 +4,7 @@ export interface IUserAPIDTO {
   surname: string;
   role: string;
   email: string;
+  sourcesOfInterest?: string[];
 }
 
 export interface IUserAPIincomingDTO extends Omit<IUserAPIDTO, 'id'> {

--- a/src/app/controllers/user.controller.ts
+++ b/src/app/controllers/user.controller.ts
@@ -70,6 +70,8 @@ export class UserController {
           <UserTokenClaims>req.user,
           sourcesOfInterest,
         );
+
+        return res.sendStatus(200);
       } catch (err: any) {
         const errorType: Exception = err.constructor.name;
         return res.status(statusMap[errorType] ?? HttpStatus.INTERNAL_SERVER_ERROR).json(err);

--- a/src/app/controllers/user.controller.ts
+++ b/src/app/controllers/user.controller.ts
@@ -55,7 +55,7 @@ export class UserController {
       }
     });
 
-    this.router.post('update-sources', isAuthenticated, async (req: Request, res: Response) => {
+    this.router.post('/update-sources', isAuthenticated, async (req: Request, res: Response) => {
       try {
         await updatedSourcesSchema.validateAsync(req.body);
       } catch (err: any) {

--- a/src/app/controllers/user.controller.ts
+++ b/src/app/controllers/user.controller.ts
@@ -7,6 +7,7 @@ import { Router, Request, Response } from 'express';
 import { inject, injectable } from 'inversify';
 import { isAuthenticated } from '../middlewares/isAuthenticated.middleware';
 import { EncryptionService } from '@services/Encryption.service';
+import { Source } from '@domain/Document';
 
 @injectable()
 export class UserController {
@@ -68,7 +69,7 @@ export class UserController {
         return res.status(statusMap[Exception.INVALID]).json(error.message);
       }
 
-      const { sourcesOfInterest }: { sourcesOfInterest: string[] } = req.body;
+      const { sourcesOfInterest }: { sourcesOfInterest: Source[] } = req.body;
 
       try {
         await this.userService.updateSourcesOfInterest(token, sourcesOfInterest);

--- a/src/app/controllers/validationSchemas/User.ts
+++ b/src/app/controllers/validationSchemas/User.ts
@@ -8,3 +8,7 @@ export const createSchema = Joi.object({
   email: Joi.string().email().required(),
   password: Joi.string().required(),
 });
+
+export const updatedSourcesSchema = Joi.object({
+  sourcesOfInterest: Joi.array().items(Joi.string()).required(),
+});

--- a/src/app/mappers/User.map.ts
+++ b/src/app/mappers/User.map.ts
@@ -16,7 +16,7 @@ export class UserMap {
       role: user.role,
       password: user.password,
       email: user.email,
-      sourcesOfInterest: user.sourcesOfInterest,
+      sources_of_interest: user.sourcesOfInterest,
     };
   }
   toDTO(user: User): IUserAPIDTO {

--- a/src/app/mappers/User.map.ts
+++ b/src/app/mappers/User.map.ts
@@ -16,6 +16,7 @@ export class UserMap {
       role: user.role,
       password: user.password,
       email: user.email,
+      sourcesOfInterest: user.sourcesOfInterest,
     };
   }
   toDTO(user: User): IUserAPIDTO {
@@ -25,6 +26,7 @@ export class UserMap {
       surname: user.surname,
       role: user.role,
       email: user.email,
+      sourcesOfInterest: user.sourcesOfInterest,
     };
   }
 }

--- a/src/app/middlewares/parseDocumentsFilters.middleware.ts
+++ b/src/app/middlewares/parseDocumentsFilters.middleware.ts
@@ -1,0 +1,29 @@
+import { Request, Response } from 'express';
+
+export interface IDocumentsFilters {
+  sourcesOfInterest?: string[];
+}
+
+export async function parseDocumentsFilters(
+  request: Request,
+  response: Response,
+  next: () => void,
+) {
+  let sourcesOfInterest: string[];
+
+  if (Array.isArray(request.query.sourcesOfInterest)) {
+    sourcesOfInterest = <string[]>request.query.sourcesOfInterest;
+  } else if (typeof request.query.sourcesOfInterest === 'string') {
+    sourcesOfInterest = [request.query.sourcesOfInterest];
+  } else {
+    sourcesOfInterest = request.query.sourcesOfInterest = [];
+  }
+
+  const documentsFilters: IDocumentsFilters = {
+    sourcesOfInterest,
+  };
+
+  request.documentsFilters = documentsFilters;
+
+  next();
+}

--- a/src/app/services/Auth.service.ts
+++ b/src/app/services/Auth.service.ts
@@ -35,6 +35,7 @@ export class AuthService {
       id: user.id,
       email: user.email,
       role: user.role,
+      sourcesOfInterest: user.sourcesOfInterest,
     });
 
     return {
@@ -60,6 +61,7 @@ export class AuthService {
       id: user.id,
       email: user.email,
       role: user.role,
+      sourcesOfInterest: user.sourcesOfInterest,
     });
     return { user, token };
   }

--- a/src/app/services/Document.service.ts
+++ b/src/app/services/Document.service.ts
@@ -12,10 +12,14 @@ export class DocumentService {
     @inject(TYPES.DOCUMENT_MAP) private mapper: DocumentMap,
   ) {}
 
-  async getAll(page = 0, pageSize = 10): Promise<IAllDocumentsOutgoingDTO> {
+  async getAll(
+    sourcesOfInterest: string[],
+    page: number,
+    pageSize: number,
+  ): Promise<IAllDocumentsOutgoingDTO> {
     const offset = page * pageSize;
 
-    const { entries, count } = await this.repository.getAll(offset, pageSize);
+    const { entries, count } = await this.repository.getAll(sourcesOfInterest, offset, pageSize);
     const dtoDocuments = entries.map((entry) => this.mapper.toDTO(entry));
     return {
       totalNumberOfResults: count,

--- a/src/app/services/Document.service.ts
+++ b/src/app/services/Document.service.ts
@@ -4,6 +4,7 @@ import { IDocumentRepository } from '@domain/Document';
 import { DocumentMap } from '@mappers';
 import { TYPES } from '@server/types';
 import { inject, injectable } from 'inversify';
+import { IDocumentsFilters } from '@middlewares/parseDocumentsFilters.middleware';
 
 @injectable()
 export class DocumentService {
@@ -13,13 +14,17 @@ export class DocumentService {
   ) {}
 
   async getAll(
-    sourcesOfInterest: string[],
+    documentsFilters: IDocumentsFilters,
     page: number,
     pageSize: number,
   ): Promise<IAllDocumentsOutgoingDTO> {
     const offset = page * pageSize;
 
-    const { entries, count } = await this.repository.getAll(sourcesOfInterest, offset, pageSize);
+    const { entries, count } = await this.repository.getAll(
+      documentsFilters.sourcesOfInterest,
+      offset,
+      pageSize,
+    );
     const dtoDocuments = entries.map((entry) => this.mapper.toDTO(entry));
     return {
       totalNumberOfResults: count,

--- a/src/app/services/Encryption.service.ts
+++ b/src/app/services/Encryption.service.ts
@@ -6,6 +6,7 @@ export interface UserTokenClaims {
   id: string;
   email: string;
   role: string;
+  sourcesOfInterest: string[];
 }
 
 @injectable()

--- a/src/app/services/User.service.ts
+++ b/src/app/services/User.service.ts
@@ -7,6 +7,7 @@ import { TYPES } from '@server/types';
 import { UserMap } from '../mappers/User.map';
 import { IUserRepository } from '@domain/User';
 import { NoSuchElementException } from '@lib';
+import { Source } from '@domain/Document';
 
 @injectable()
 export class UserService {
@@ -41,7 +42,7 @@ export class UserService {
     return this.userMap.toDTO(savedUser);
   }
 
-  async updateSourcesOfInterest(token: string, sourcesOfInterest: string[]) {
+  async updateSourcesOfInterest(token: string, sourcesOfInterest: Source[]) {
     const claims = this.encryptionService.verify<UserTokenClaims>(token);
     const user = await this.repository.getById(claims.id);
 

--- a/src/app/services/User.service.ts
+++ b/src/app/services/User.service.ts
@@ -51,6 +51,11 @@ export class UserService {
 
     user.updateSources(sourcesOfInterest);
 
-    await this.repository.update(this.userMap.toPersistence(user));
+    try {
+      await this.repository.update(this.userMap.toPersistence(user));
+    } catch (e: any) {
+      console.log(e);
+      throw new Error(e);
+    }
   }
 }

--- a/src/app/services/User.service.ts
+++ b/src/app/services/User.service.ts
@@ -42,8 +42,7 @@ export class UserService {
     return this.userMap.toDTO(savedUser);
   }
 
-  async updateSourcesOfInterest(token: string, sourcesOfInterest: Source[]) {
-    const claims = this.encryptionService.verify<UserTokenClaims>(token);
+  async updateSourcesOfInterest(claims: UserTokenClaims, sourcesOfInterest: Source[]) {
     const user = await this.repository.getById(claims.id);
 
     if (!user) {

--- a/src/domain/Document/Document.repository.interface.ts
+++ b/src/domain/Document/Document.repository.interface.ts
@@ -2,7 +2,11 @@ import { IDocumentPersistenceDTO } from '@persistence/dtos/Document';
 import { Document } from './Document';
 
 export interface IDocumentRepository {
-  getAll(offset?: number, limit?: number): Promise<{ entries: Document[]; count: number }>;
+  getAll(
+    sourcesOfInterest?: string[],
+    offset?: number,
+    limit?: number,
+  ): Promise<{ entries: Document[]; count: number }>;
   save(dto: IDocumentPersistenceDTO): Promise<Document>;
   update(dto: IDocumentPersistenceDTO): Promise<Document>;
   getById(id: string): Promise<Document | null>;

--- a/src/domain/Document/Document.ts
+++ b/src/domain/Document/Document.ts
@@ -4,6 +4,12 @@ export enum Status {
   REVIZUIT = 'revizuit',
 }
 
+export enum Source {
+  CAMERA_DEPUTATILOR = 'CAMERA_DEPUTATILOR',
+  SENAT = 'SENAT',
+  GUVERN = 'GUVERN',
+}
+
 export interface IDocumentProps {
   id: string;
   createdAt: Date;

--- a/src/domain/Document/Document.ts
+++ b/src/domain/Document/Document.ts
@@ -5,9 +5,9 @@ export enum Status {
 }
 
 export enum Source {
-  CAMERA_DEPUTATILOR = 'CAMERA_DEPUTATILOR',
-  SENAT = 'SENAT',
-  GUVERN = 'GUVERN',
+  CAMERA_DEPUTATILOR = 'camera_deputatilor',
+  SENAT = 'senat',
+  GUVERN = 'guvern',
 }
 
 export interface IDocumentProps {

--- a/src/domain/Document/Document.ts
+++ b/src/domain/Document/Document.ts
@@ -18,7 +18,7 @@ export interface IDocumentProps {
   project: string;
   identifier: string;
   publicationDate: Date;
-  source: string;
+  source: Source;
   status: Status;
   isRulesBreaker?: boolean;
   assignedUser: string | null;
@@ -39,7 +39,7 @@ export class Document {
   project: string;
   identifier: string;
   publicationDate: Date;
-  source: string;
+  source: Source;
   status: Status;
   isRulesBreaker: boolean;
   assignedUser: string | undefined;

--- a/src/domain/User/User.ts
+++ b/src/domain/User/User.ts
@@ -14,7 +14,7 @@ export interface IUserProps {
   role: string;
   password: string;
   email: string;
-  sourcesOfInterest?: Source[];
+  sources_of_interest?: Source[];
 }
 
 export class User {
@@ -32,7 +32,7 @@ export class User {
     this.role = props.role;
     this.email = props.email;
     this.password = props.password;
-    this.sourcesOfInterest = props.sourcesOfInterest ?? [];
+    this.sourcesOfInterest = props.sources_of_interest ?? [];
   }
 
   public updatePassword(newPassword: string): void {

--- a/src/domain/User/User.ts
+++ b/src/domain/User/User.ts
@@ -12,6 +12,7 @@ export interface IUserProps {
   role: string;
   password: string;
   email: string;
+  sourcesOfInterest?: string[];
 }
 
 export class User {
@@ -21,6 +22,7 @@ export class User {
   role: string;
   email: string;
   password: string;
+  sourcesOfInterest: string[];
   private constructor(props: IUserProps) {
     this.name = props.name;
     this.id = props.id ?? 'random generated string';
@@ -28,10 +30,15 @@ export class User {
     this.role = props.role;
     this.email = props.email;
     this.password = props.password;
+    this.sourcesOfInterest = props.sourcesOfInterest ?? [];
   }
 
   public updatePassword(newPassword: string): void {
     this.password = newPassword;
+  }
+
+  public updateSources(newSources: string[]): void {
+    this.sourcesOfInterest = newSources;
   }
 
   public static create(props: IUserProps) {

--- a/src/domain/User/User.ts
+++ b/src/domain/User/User.ts
@@ -1,3 +1,5 @@
+import { Source } from '@domain/Document';
+
 export enum Role {
   ITA = 'ITA', // IT Administrator
   LSE = 'LSE', // Legislation Screening Expert
@@ -12,7 +14,7 @@ export interface IUserProps {
   role: string;
   password: string;
   email: string;
-  sourcesOfInterest?: string[];
+  sourcesOfInterest?: Source[];
 }
 
 export class User {
@@ -22,7 +24,7 @@ export class User {
   role: string;
   email: string;
   password: string;
-  sourcesOfInterest: string[];
+  sourcesOfInterest: Source[];
   private constructor(props: IUserProps) {
     this.name = props.name;
     this.id = props.id ?? 'random generated string';
@@ -37,7 +39,7 @@ export class User {
     this.password = newPassword;
   }
 
-  public updateSources(newSources: string[]): void {
+  public updateSources(newSources: Source[]): void {
     this.sourcesOfInterest = newSources;
   }
 

--- a/src/domain/User/User.ts
+++ b/src/domain/User/User.ts
@@ -36,10 +36,12 @@ export class User {
   }
 
   public updatePassword(newPassword: string): void {
+    // extra logic and/or validation
     this.password = newPassword;
   }
 
   public updateSources(newSources: Source[]): void {
+    // extra logic and/or validation
     this.sourcesOfInterest = newSources;
   }
 

--- a/src/persistence/Document/Document.mock.repository.ts
+++ b/src/persistence/Document/Document.mock.repository.ts
@@ -1,4 +1,4 @@
-import { Document, IDocumentRepository, Status } from '@domain/Document';
+import { Document, IDocumentRepository, Source, Status } from '@domain/Document';
 import { DocumentMap } from '@mappers';
 import { IDocumentPersistenceDTO } from '@persistence/dtos';
 import { TYPES } from '@server/types';
@@ -18,7 +18,7 @@ export class DocumentMockRepository implements IDocumentRepository {
       identifier: '1',
       isRulesBreaker: false,
       publicationDate: new Date(),
-      source: 'senat',
+      source: Source.SENAT,
       status: Status.NOU,
       assignedUser: '822b7f37-1faa-4da5-8bd6-ee75eb59613e',
       deadline: null,

--- a/src/persistence/Document/Document.repository.ts
+++ b/src/persistence/Document/Document.repository.ts
@@ -18,11 +18,16 @@ export class DocumentRepository implements IDocumentRepository {
     this.entityRepository = entityManager.getRepository(DocumentSchema);
   }
 
-  async getAll(offset = 0, limit = 0) {
-    const [entries, count] = await this.entityRepository.findAndCount(
-      {},
-      { limit, offset, populate: ['project'] },
-    );
+  async getAll(sourcesOfInterest: string[], offset = 0, limit = 0) {
+    const sourceCondition =
+      sourcesOfInterest.length === 0 ? {} : { source: { $in: sourcesOfInterest } };
+
+    const [entries, count] = await this.entityRepository.findAndCount(sourceCondition, {
+      limit,
+      offset,
+      populate: ['project'],
+    });
+
     return {
       entries: entries.map((entry) => this.mapper.toDomain(entry)),
       count,

--- a/src/persistence/User/User.schema.ts
+++ b/src/persistence/User/User.schema.ts
@@ -1,5 +1,6 @@
 import { IUserPersistenceDTO } from './../dtos/User';
 import { EntitySchema } from '@mikro-orm/core';
+import { Source } from '@domain/Document';
 
 export const UserSchema = new EntitySchema<IUserPersistenceDTO>({
   name: 'User',
@@ -10,5 +11,6 @@ export const UserSchema = new EntitySchema<IUserPersistenceDTO>({
     role: { type: 'string' }, // todo: use role enum here, defaults to generic user https://mikro-orm.io/docs/defining-entities#enum-arrays
     email: { type: 'string', unique: true },
     password: { type: 'string' },
+    sources_of_interest: { enum: true, array: true, default: [], items: () => Source },
   },
 });

--- a/src/persistence/dtos/Document.ts
+++ b/src/persistence/dtos/Document.ts
@@ -1,4 +1,4 @@
-import { Status } from '@domain/Document';
+import { Source, Status } from '@domain/Document';
 export interface IDocumentPersistenceIncomingDTO {
   title: string;
   project: string;
@@ -24,7 +24,7 @@ export interface IDocumentPersistenceDTO {
   project: string;
   identifier: string;
   publicationDate: Date;
-  source: string; // maybe replace with source entity?
+  source: Source;
   status: Status;
   isRulesBreaker: boolean;
   assignedUser: string | null;

--- a/src/persistence/dtos/User.ts
+++ b/src/persistence/dtos/User.ts
@@ -1,3 +1,5 @@
+import { Source } from '@domain/Document';
+
 export interface IUserPersistenceDTO {
   id: string;
   name: string;
@@ -5,5 +7,5 @@ export interface IUserPersistenceDTO {
   role: string;
   password: string;
   email: string;
-  sourcesOfInterest?: string[];
+  sourcesOfInterest?: Source[];
 }

--- a/src/persistence/dtos/User.ts
+++ b/src/persistence/dtos/User.ts
@@ -7,5 +7,5 @@ export interface IUserPersistenceDTO {
   role: string;
   password: string;
   email: string;
-  sourcesOfInterest?: Source[];
+  sources_of_interest?: Source[];
 }

--- a/src/persistence/dtos/User.ts
+++ b/src/persistence/dtos/User.ts
@@ -5,4 +5,5 @@ export interface IUserPersistenceDTO {
   role: string;
   password: string;
   email: string;
+  sourcesOfInterest?: string[];
 }

--- a/src/persistence/migrations/.snapshot-screening.json
+++ b/src/persistence/migrations/.snapshot-screening.json
@@ -125,6 +125,21 @@
           "primary": false,
           "nullable": false,
           "mappedType": "string"
+        },
+        "sources_of_interest": {
+          "name": "sources_of_interest",
+          "type": "text[]",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "'{}'",
+          "enumItems": [
+            "CAMERA_DEPUTATILOR",
+            "SENAT",
+            "GUVERN"
+          ],
+          "mappedType": "array"
         }
       },
       "name": "user",

--- a/src/persistence/migrations/Migration20221205090325.ts
+++ b/src/persistence/migrations/Migration20221205090325.ts
@@ -1,0 +1,13 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20221205090325 extends Migration {
+
+  async up(): Promise<void> {
+    this.addSql('alter table "user" add column "sources_of_interest" text[] not null default \'{}\';');
+  }
+
+  async down(): Promise<void> {
+    this.addSql('alter table "user" drop column "sources_of_interest";');
+  }
+
+}

--- a/src/server/types/express/index.d.ts
+++ b/src/server/types/express/index.d.ts
@@ -1,3 +1,4 @@
+import { IDocumentsFilters } from '@middlewares/parseDocumentsFilters.middleware';
 import { UserTokenClaims } from '@services/Encryption.service';
 
 export {};
@@ -6,6 +7,7 @@ declare global {
   namespace Express {
     export interface Request {
       user?: UserTokenClaims;
+      documentsFilters?: IDocumentsFilters;
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,8 @@
       "@services/*": ["app/services/*"],
       "@mappers": ["app/mappers"],
       "@mappers/*": ["app/mappers/*"],
+      "@middlewares": ["app/middlewares"],
+      "@middlewares/*": ["app/middlewares/*"],
       "@domain": ["domain/"],
       "@domain/*": ["domain/*"],
       "@repos": ["domain/repos"],


### PR DESCRIPTION
- added sources_of_interest to user entity
- added endpoint to update sources of interest for an user
- added source of interest parameter(1) to get documents query
- added some(2) authorization to get documents query
- added migration:up when starting app in dev

1. examples of usage with array:

this will query for `guvern` and `senat` entries
   http://localhost:3000/document?sourcesOfInterest=guvern&sourcesOfInterest=senat

this will query for `senat` entries
   http://localhost:3000/document?sourcesOfInterest=guvern

this will query for all entries
   http://localhost:3000/document

2.

Only check to have AN authorisation header. TBD exactly what level of authorization we need here. 
